### PR TITLE
Issue #9

### DIFF
--- a/src/fivefieldkono/Play.java
+++ b/src/fivefieldkono/Play.java
@@ -3,16 +3,64 @@ package fivefieldkono;
 import javaboard.Executor;
 import javaboard.Player;
 import javaboard.PlayerCPURandom;
+import javaboard.PlayerHumanTerminal;
+
+import java.util.Scanner;
+import java.io.*;
 
 public class Play {
 
     // Play a FiveFieldKono using the Executor
     public static void main(String[] args) {
-        FiveFieldKono game = new FiveFieldKono();
+        Scanner scan_command = new Scanner(System.in);
+        while(true){
+            System.out.println("Type 'load' to load a game from a savefile.");
+            System.out.println("Type 'exit' to close the game.");
+            System.out.println("Type anything else (or nothing at all) to start a new game.");
+            System.out.println(">Please type according to the command you wish to use:");
+            
+            String input = scan_command.nextLine();
+            if (input.equals("exit")) break;
+            if (input.equals("load")) {
+                System.out.println("> Specify number of slot to load from (1 to 9). Type anything else to return to move selection");
+                String number = scan_command.nextLine();
+                try{
+                    Integer slot = Integer.parseInt(number);
+                
+                    if (slot > 0 && slot<10){
+                        try {
+                            FiveFieldKono load = null;
+                            String selected_slot = "src/fivefieldkono/save/FFKSave"+number+".ser";
+                            FileInputStream load_file = new FileInputStream(selected_slot);
+                            ObjectInputStream load_from = new ObjectInputStream(load_file);
+                            load = (FiveFieldKono) load_from.readObject();
+                            load_from.close();
+                            load_file.close();
+                            System.out.println("The game has been loaded!");
+                            Player[] players = {new PlayerHumanTerminal(), new PlayerCPURandom()};
+                            Executor loaded_match = new Executor();
+                            loaded_match.runGame(load, players);
+                        } catch (IOException SerializableError) {
+                            System.out.println("Couldn't find the save file...");
+                            SerializableError.printStackTrace();
+                        } catch (ClassNotFoundException ClassError) {
+                            System.out.println("Invalid save file.");
+                            ClassError.printStackTrace();
+                        }
+                    }
+                } catch (NumberFormatException WrongNumber) {
+                    System.out.println("Not a valid number.");
+                }
+            }
+            else{
+                FiveFieldKono game = new FiveFieldKono();
 
-        Player[] players = {new PlayerCPURandom(), new PlayerCPURandom()};
+                Player[] players = {new PlayerHumanTerminal(), new PlayerCPURandom()};
 
-        Executor exec = new Executor();
-        exec.runGame(game,players);
+                Executor exec = new Executor();
+                exec.runGame(game,players);
+            }
+        }
+        scan_command.close();
     }
 }

--- a/src/fivefieldkono/Play.java
+++ b/src/fivefieldkono/Play.java
@@ -30,7 +30,7 @@ public class Play {
                     if (slot > 0 && slot<10){
                         try {
                             FiveFieldKono load = null;
-                            String selected_slot = "src/fivefieldkono/save/FFKSave"+number+".ser";
+                            String selected_slot = "src/fivefieldkono/FFKSave"+number+".ser";
                             FileInputStream load_file = new FileInputStream(selected_slot);
                             ObjectInputStream load_from = new ObjectInputStream(load_file);
                             load = (FiveFieldKono) load_from.readObject();

--- a/src/javaboard/Executor.java
+++ b/src/javaboard/Executor.java
@@ -26,10 +26,18 @@ public class Executor {
             // Current player decides
             Movement pick = players[state.current_player].pickMovement(state,moves,null);
 
+            // set winner to -1 (Nobody) if the human player chose to exit to load/new game menu.
+            if (pick.command.equals("yes")){
+                winner = -1;
+                break;
+            }
+
             // Update current state
             state = pick.result;
         }
 
+        // Close current game with no winner
+        if (winner==-1) return winner;
         // Print player's victory message
         System.out.println("Jugador "+winner+": "+players[winner].victoryMessage());
 

--- a/src/javaboard/Game.java
+++ b/src/javaboard/Game.java
@@ -4,7 +4,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 // Represents a current game state and its rules
-public abstract class Game {
+public abstract class Game implements java.io.Serializable {
 
     // List of pieces
     public List<Piece> pieces;

--- a/src/javaboard/Piece.java
+++ b/src/javaboard/Piece.java
@@ -3,7 +3,7 @@ package javaboard;
 import java.util.List;
 
 // A piece in the board
-public abstract class Piece {
+public abstract class Piece implements java.io.Serializable {
     // Piece position
     public int x,y;
     // Current piece player

--- a/src/javaboard/PlayerHumanTerminal.java
+++ b/src/javaboard/PlayerHumanTerminal.java
@@ -52,7 +52,7 @@ public class PlayerHumanTerminal extends Player {
                  
                     if (slot > 0 && slot<10){
                         try {
-                            String selected_slot = "src/fivefieldkono/save/FFKSave"+number+".ser";
+                            String selected_slot = "src/fivefieldkono/FFKSave"+number+".ser";
                             Game save_game = state.cloneGame();
                             FileOutputStream save_file = new FileOutputStream(selected_slot);
                             ObjectOutputStream save_to = new ObjectOutputStream(save_file);

--- a/src/javaboard/PlayerHumanTerminal.java
+++ b/src/javaboard/PlayerHumanTerminal.java
@@ -3,6 +3,8 @@ package javaboard;
 import java.util.List;
 import java.util.Scanner;
 
+import java.io.*;
+
 // A human player that picks movements from the terminal using their command strings
 public class PlayerHumanTerminal extends Player {
 
@@ -18,17 +20,57 @@ public class PlayerHumanTerminal extends Player {
         }
         System.out.println();
 
-        // Expect comand
+        // Expect command
         Movement input_move = null;
         Scanner scan_in = new Scanner(System.in);
         while(true){
-            System.out.println("> Insert movement:");
+            System.out.println("You can insert a movement, or insert 'save' or 'exit' for saving or closing the current match.");
+            System.out.println("> Insert a movement or command:");
             String input = scan_in.nextLine();
 
             for(Movement mov : options){
                 if(mov.command.equals(input)){
                     input_move = mov;
                 }
+            }
+            // Command "exit" enables the user to close current match and load or create a different game.
+            if (input.equals("exit")) {
+                System.out.println("Exit current match? Any unsaved progress will be lost. Type 'yes' to confirm.");
+                String exit_selection = scan_in.nextLine();
+                if (exit_selection.equals("yes")){
+                    Movement exit_command = new Movement(exit_selection, state);
+                    input_move = exit_command;
+                }
+                else continue;
+            }
+            // Command "save" for making a save file for the ongoing match.
+            if (input.equals("save")) {
+                System.out.println("> Specify number of slot to save at (1 to 9). Type anything else to return to move selection");
+                String number = scan_in.nextLine();
+                try{
+                    Integer slot = Integer.parseInt(number);
+                 
+                    if (slot > 0 && slot<10){
+                        try {
+                            String selected_slot = "src/fivefieldkono/save/FFKSave"+number+".ser";
+                            Game save_game = state.cloneGame();
+                            FileOutputStream save_file = new FileOutputStream(selected_slot);
+                            ObjectOutputStream save_to = new ObjectOutputStream(save_file);
+                            save_to.writeObject(save_game);
+                            save_to.close();
+                            save_file.close();
+                            System.out.println("Saved!");
+                        } catch (IOException SerializableError) {
+                            SerializableError.printStackTrace();
+                        }
+                    }
+                    else {
+                        System.out.println("returning to movement selection...");
+                    }
+                } catch (NumberFormatException wrong_number){
+                    System.out.println("Not a valid number.");
+                }
+                continue;
             }
             // Valid command, break
             if(input_move != null) break;


### PR DESCRIPTION
**Nombre:** Víctor David Abarca Castro **Rol:** 201773092-7
Se crearon las funciones de guardado y cargado de partidas en el juego Five Field Kono, utilizando la interfaz `Serializable` de `Java.io.Serializable`, para permitir al usuario guardar la partida que juega actualmente hasta en 9 espacios diferentes, cargarlos desde el "menú inicial" del juego.

El usuario puede ingresar "save" en vez de un comando para proceder a seleccionar el número de guardado, así como puede ingresar "exit" para salir del juego actual, con una advertencia de perder los datos de partida si ésta no se ha guardado. En el menú principal, el usuario puede elegir entre iniciar una nueva partida, salir del juego y terminar el programa, o cargar una partida previamente guardada.

##Cambios generales
Se modificó Game y Piece para que implementen la interfaz `Serializable`, como consecuencia, las subclases `FiveFieldKono` y `KonoPiece` también son Serializables. Esto permite que estas clases puedan ser escritas y leídas como bytes en archivos. Se utilizó la extensión `.ser` para este procedimiento.

## Guardado de partidas
Para guardar partidas, se añadió a `PlayerHumanTerminal` un bloque que actúa cuando el usuario ingrese "save" como comando, y procede a pedir el dígito de la partida para guardar, en un rango del 1 al 9. Ingresar un número fuera de este rango o no ingresar sólamente números resultará en regresar a la selección de comando o movimientos. también se ingresó un bloque que recibe el comando "exit", que muestra la advertencia y pide confirmación del usuario. El bloque asigna un movimiento ingresado y lo envía a `Executor` al igual que un comando de movimiento. `Executor` fue modificado para recibir esta respuesta y asignar -1 a la variable `winner` (valor negativo para no colisionar con la identificación numérica de los jugadores), en cuyo caso Executor rompe el ciclo que mantiene el juego, y no se imprime mensaje de victoria (ya que no se ha determinado un jugador como ganador), haciendo que el usuario regrese al menú inicial del programa.

## Cargado de partidas
Para cargar partidas, se modificó `Play` para generar un ciclo. Dentro de este ciclo, se muestran las opciones de iniciar una nueva partida, cargar una partida, o salir del juego:
 - "exit" romperá el ciclo y terminará el programa.
 - "load" procederá a cargar una partida dependiente del dígito que el usuario escoja. No cargará la partida si el archivo es inválido o no existe, y regresará al menú principal. 
 - ingresar cualquier otra respuesta procederá a iniciar una nueva partida.